### PR TITLE
20220613 setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
 .PHONY: init
 init:
-	pip install --upgrade pip flit
+	pip install --upgrade pip setuptools wheel pip-tools
 
 .PHONY: install
 install:
 	[ -f "requirements.txt" ] && pip install -r requirements.txt || true
-	flit install
+	pip install --upgrade .
 
 .PHONY: install-dev
 install-dev:
 	[ -f "requirements.txt" ] && pip install -r requirements.txt || true
 	[ -f "requirements-dev.txt" ] && pip install -r requirements-dev.txt || true
-	flit install --symlink
+	pip install --editable .
 	pre-commit install
 
 .PHONY: build-dist
 build-dist:
-	flit build
+	python setup.py sdist bdist_wheel
 
 .PHONY: clean-artifacts
 clean-artifacts:

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 .PHONY: init
 init:
-	pip install --upgrade pip setuptools wheel pip-tools
+	python -m pip install --upgrade pip setuptools wheel
 
 .PHONY: install
 install:
 	[ -f "requirements.txt" ] && pip install -r requirements.txt || true
-	pip install --upgrade .
+	python -m pip install --upgrade .
 
 .PHONY: install-dev
 install-dev:
 	[ -f "requirements.txt" ] && pip install -r requirements.txt || true
 	[ -f "requirements-dev.txt" ] && pip install -r requirements-dev.txt || true
-	pip install --editable .
+	python -m pip install --editable .
 	pre-commit install
 
 .PHONY: build-dist

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ install-dev:
 
 .PHONY: build-dist
 build-dist:
-	python setup.py sdist bdist_wheel
+	pip install --upgrade build
+	python -m build
 
 .PHONY: clean-artifacts
 clean-artifacts:

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Run tests:
 tox [-r] [-e py3x]
 ```
 
+Build dist:
+
+```bash
+python -m pip install --upgrade build
+
+python -m build
+```
+
 To deactivate (exit) the `venv`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,15 +21,14 @@ Straight forward to use!
 ### Single module projects
 
 - Rename `module_example.py` as desired
-  - `[project]` `name` value must match file name
 - Update requirements.txt as needed
 - *Optional* Use `pyproject.toml` for dependencies and optional-dependencies instead
 
 ### Multi file module projects
 
 - All the steps above
-- `[project]` `name` value must match module folder
-- *Optional*: Set `[tool.flit.module]` if [project name and module folder differ](https://flit.pypa.io/en/latest/pyproject_toml.html#module-section)
+- If more than one module folder exists:
+  - Uncomment and set `[tool.setuptools.packages.find]` in `pyproject.tolm`
 
 ### GitHub Actions
 
@@ -93,8 +92,8 @@ call the version of the interpreter used to create the `venv`
 Install editable library and development requirements:
 
 ```bash
-# Update pip and install flit
-python -m pip install --upgrade pip flit
+# Update pip, setuptools, and wheel
+python -m pip install --upgrade pip setuptools wheel pip-tools
 
 # Install development requirements
 python -m pip install -r requirements-dev.txt
@@ -103,10 +102,10 @@ python -m pip install -r requirements-dev.txt
 python -m pip install -r requirements.txt
 
 # Install package
-flit install
+pip install .
 
 # Optional: install editable package (pip install -e)
-flit install --symlink
+pip install --editable .
 ```
 
 Install pre-commit [(see below for details)](#pre-commit):
@@ -167,13 +166,13 @@ This repo has a Makefile with some quality of life scripts if the system
 supports `make`.  Please note there are no checks for an active `venv` in the
 Makefile.
 
-| PHONY             | Description                                                        |
-| ----------------- | ------------------------------------------------------------------ |
-| `init`            | Install/Update pip and flit                                        |
-| `install`         | install project and requirements                                   |
-| `install-dev`     | install dev requirements, project as editable, and pre-commit      |
-| `build-dist`      | Build source distribution and wheel distribution                   |
-| `clean-artifacts` | Deletes python/mypy artifacts including eggs, cache, and pyc files |
-| `clean-tests`     | Deletes tox, coverage, and pytest artifacts                        |
-| `clean-build`     | Deletes build artifacts                                            |
-| `clean-all`       | Runs all clean scripts                                             |
+| PHONY             | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
+| `init`            | Install/Update pip, setuptools, and wheel                     |
+| `install`         | install project and requirements                              |
+| `install-dev`     | install dev requirements, project as editable, and pre-commit |
+| `build-dist`      | Build source distribution and wheel distribution              |
+| `clean-artifacts` | Deletes python/mypy artifacts, cache, and pyc files           |
+| `clean-tests`     | Deletes tox, coverage, and pytest artifacts                   |
+| `clean-build`     | Deletes build artifacts                                       |
+| `clean-all`       | Runs all clean scripts                                        |

--- a/module_example.py
+++ b/module_example.py
@@ -3,6 +3,7 @@
 
 def main() -> bool:
     """Main"""
+    print("The square of 2 is:", squared(2))
     return True
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "module_example"
@@ -37,6 +37,14 @@ homepage = "https://github.com/[your repo]/[repo name]"
 
 [project.scripts]
 python-module-example = "module_example:main"
+
+# Use only for package discovery with single distro of multiple packages.
+# Let setuptools handle the rest.
+# [tool.setuptools.packages.find]
+# where = ["."]  # ["."] by default
+# include = ["*"]  # ["*"] by default
+# exclude = ["tests"]  # empty by default
+# namespaces = true  # true by default
 
 [tool.mypy]
 check_untyped_defs = true

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+"""Legacy for setuptools editable install only"""
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Small revert back to `setuptools` as I learn more about the `pyproject.toml` inner workings. This will, hopefully, ensure some backward compatibility for older `pip` setups. It also resolves a side issue of using my own template at my job.